### PR TITLE
New data sources in Europe

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,9 @@ Collections of URLs pointing to traffic information portals which contain open d
   * [Entire UK](http://www.dft.gov.uk/traffic-counts/) traffic count only
   * [Here](https://data.gov.uk/dataset/dft-eng-srn-routes-journey-times) seems to be some traffic flow data.
   * [Scotland](https://trafficscotland.org/datex/): various Datex-II data sets, registration required.
-* [Gothenbury, Sweden](http://www.statistik.tkgbg.se/)
+* Sweden:
+  * [Gothenbury](http://www.statistik.tkgbg.se/)
+  * [Various data sets in Datex-II](https://www.trafikverket.se/tjanster/Oppna_data/oppna-data-vi-erbjuder/), registration required
 * [Switzerland](https://www.astra.admin.ch/astra/en/home/dokumentation/verkehrsdaten.html) traffic count only
 * France
   * [Traffic count](https://www.quandl.com/data/INSEE?keyword=traffic)

--- a/README.md
+++ b/README.md
@@ -13,7 +13,10 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [Nordrhein-Westfalen, DE](https://open.nrw/dataset/verkehrszentrale-verkehrsinformationen-der-viz-nrw-fuer-nordrhein-westfalen-1476687235163) and [other data](https://open.nrw/dataset/verkehrszentrale-verkehrslage-los-1476688071631).
 * [Entire DE (broken)](https://www.mcloud.de/web/guest/suche/-/results/detail/verkehrsdatenautomatischedauerzhlstellen) traffic count only
 * [Entire DE BASt](https://www.bast.de/BASt_2017/DE/Verkehrstechnik/Fachthemen/v2-verkehrszaehlung/Daten/2017_1/Jawe2017.html?nn=1819490) traffic count only
-* [Entire UK](http://www.dft.gov.uk/traffic-counts/) traffic count only, but [here](https://data.gov.uk/dataset/dft-eng-srn-routes-journey-times) seems to be some traffic flow data.
+* UK:
+  * [Entire UK](http://www.dft.gov.uk/traffic-counts/) traffic count only
+  * [Here](https://data.gov.uk/dataset/dft-eng-srn-routes-journey-times) seems to be some traffic flow data.
+  * [Scotland](https://trafficscotland.org/datex/): various Datex-II data sets, registration required.
 * [Gothenbury, Sweden](http://www.statistik.tkgbg.se/)
 * [Switzerland](https://www.astra.admin.ch/astra/en/home/dokumentation/verkehrsdaten.html) traffic count only
 * France

--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ Collections of URLs pointing to traffic information portals which contain open d
   * `wegwerkzaamheden`: roadworks and event-related traffic measures
   * There are also various measured data publications, indicating traffic flow, speed, travel times and queues.
   
-  The Datex-II situation reports rely heavily on Alert-C for location encoding. However, they do not use the regular Alert-C location code list for the Netherlands, but the [VILD](https://docs.ndw.nu/en/sb/algemeen/specialisatie/VILD.html), which has incompatible lcoation codes. It can be downloaded from https://www.ndw.nu/documenten/nl/#cat_2.
+  The Datex-II situation reports rely heavily on Alert-C for location encoding. However, they do not use the regular Alert-C location code list for the Netherlands, but the [VILD](https://docs.ndw.nu/en/sb/algemeen/specialisatie/VILD.html), which has incompatible lcoation codes. It can be downloaded from https://www.ndw.nu/documenten/nl/#cat_2. A semi-automatic process to convert the VILD to a Location Table Exchange Format, as understood by Alert-C toolchains, is described [here](https://gitlab.com/traffxml/vild2ltef).
  * Lithuania:
    * [traffic count](http://lakd.lrv.lt/lt/atviri-duomenys)
    * [restrictions](http://restrictions.eismoinfo.lt/): Roadworks, road closures and restrictions, incidents; JSON-based format similar to Waze CIFS. More information at http://eismoinfo.lt > Open data/Atviri duomenys.
@@ -59,6 +59,11 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [Catalonia](http://www.gencat.cat/transit/opendata/incidenciesGML.xml): traffic events, custom XML format.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
+
+EU authorities rely heavily on the Datex-II format for data exchange. Many of these data sets use Alert-C for location referencing and require a location code list (LCL) for location lookup.
+* In most cases the LCL can be obtained free of charge (at least for the countries which rely on Alert-C in their Datex-II feeds) and can be incorporated in applications, devices and information services, but some impose restrictions on redistribution of the raw tables. The [OSM Wiki](https://wiki.openstreetmap.org/wiki/TMC#Available_datasets) has a list of sources where LCLs can be obtained.
+* A FOSS Java library for location decoding is available here: [traff-libalertclocation](https://gitlab.com/traffxml/traff-libalertclocation) Decoding an Alert-C location requires the country code, location table number (LTN) and location code.
+* Some sources supply an incorrect LTN; ignore the `alertCLocationTableNumber` elements in the data and use the correct one instead. (The only exception being the Netherlands, see above.)
 
 ## Australia
 

--- a/README.md
+++ b/README.md
@@ -56,6 +56,7 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [Luxembourg](http://www.cita.lu/info_trafic/datex/situationrecord): Traffic events in Datex-II format. Relies on Alert-C for location referencing.
 * [Norway](https://www.vegvesen.no/om+statens+vegvesen/om+organisasjonen/apne-data/Datex/publikasjoner): Various data sets in Datex-II format, requires registration. Relies on Alert-C for location referencing, the LCL can be downloaded from the site.
 * [Slovenia](https://www.promet.si/portal/en/etd.aspx): various data sets in Datex-II format, requires registration.
+* [Catalonia](http://www.gencat.cat/transit/opendata/incidenciesGML.xml): traffic events, custom XML format.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -4,8 +4,10 @@ Collections of URLs pointing to traffic information portals which contain open d
 
 ## Europe
 
-* [Bolzano, Italy](http://traffic.bz.it/) documentation [here](http://ipchannels.integreen-life.bz.it/doc/), repo [here](https://github.com/tis-innovation-park/BZtraffic). See [#1](https://github.com/graphhopper/open-traffic-collection/pull/1)
-* [Turin, Italy](http://opendata.5t.torino.it/get_fdt) documentation [here](http://www.5t.torino.it/wp-content/uploads/2016/04/flussi_traffico_rt.pdf). See [#13](https://github.com/graphhopper/open-traffic-collection/issues/13)
+* Italy:
+  * [Bolzano](http://traffic.bz.it/) documentation [here](http://ipchannels.integreen-life.bz.it/doc/), repo [here](https://github.com/tis-innovation-park/BZtraffic). See [#1](https://github.com/graphhopper/open-traffic-collection/pull/1)
+  * South Tyrol: [traffic reports](https://www.europeandataportal.eu/data/#/datasets/p_bz-webservices-southtyrolean-trafficreport-currentsituation), [mountain pass conditions and closures](https://www.europeandataportal.eu/data/#/datasets/p_bz-webservices-southtyrolean-trafficreport-mountainroadsandpasses), [roadworks and closures](https://www.europeandataportal.eu/data/#/datasets/p_bz-webservices-southtyrolean-trafficreport-works-closings). They also advertise [reports from neighboring regions](https://www.europeandataportal.eu/data/#/datasets/p_bz-webservices-southtyrolean-trafficreport-outofprovince) but the feed seems to be empty. Available custom GML, JSON or CSV formats.
+  * [Turin, Italy](http://opendata.5t.torino.it/get_fdt) documentation [here](http://www.5t.torino.it/wp-content/uploads/2016/04/flussi_traffico_rt.pdf). See [#13](https://github.com/graphhopper/open-traffic-collection/issues/13)
 * [Cologne, Germany](http://www.offenedaten-koeln.de/dataset/verkehrskalender-der-stadt-k%C3%B6ln), CC BY 3.0, traffic flow. See this [blog post](https://www.graphhopper.com/blog/2015/04/08/visualize-and-handle-traffic-information-with-graphhopper-in-real-time-for-cologne-germany-koln/)
 * [Jena, Germany](https://opendata.jena.de/group/mobilitat)
 * [Darmstadt, Germany](https://darmstadt.ui-traffic.de/faces/TrafficData.xhtml)

--- a/README.md
+++ b/README.md
@@ -18,7 +18,15 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [Switzerland](https://www.astra.admin.ch/astra/en/home/dokumentation/verkehrsdaten.html) traffic count only
 * [France](https://www.quandl.com/data/INSEE?keyword=traffic) traffic count only
 * [Historic Road data in EU](http://open-data.europa.eu/en/data/dataset/4t2lYOaJNRsEgDA37hrUgg)
-* [Netherlands](http://83.247.110.3/ndwOpenAVG/Default.aspx) via the NDW. FTP-Server for data and measurements is ftp://83.247.110.3/ , see [#2](https://github.com/graphhopper/open-traffic-collection/issues/2)
+* [Netherlands](http://83.247.110.3/ndwOpenAVG/Default.aspx) via the NDW. FTP-Server for data and measurements is ftp://83.247.110.3/ , see [#2](https://github.com/graphhopper/open-traffic-collection/issues/2). Feeds are also available at http://opendata.ndw.nu/. Specifically:
+  * `brugopeningen` has time tables for movable bridges, indicating when they are opened (i.e. raised) and thus impassable for road traffic
+  * `gebeurtenisinfo`: traffic messages, e.g. traffic jams, wrong-way drivers, closures, detours and weather conditions
+  * `incidents`: Breakdowns and accidents
+  * `srti` has safety-related traffic information
+  * `wegwerkzaamheden`: roadworks and event-related traffic measures
+  * There are also various measured data publications, indicating traffic flow, speed, travel times and queues.
+  
+  The Datex-II situation reports rely heavily on Alert-C for location encoding. However, they do not use the regular Alert-C location code list for the Netherlands, but the [VILD](https://docs.ndw.nu/en/sb/algemeen/specialisatie/VILD.html), which has incompatible lcoation codes. It can be downloaded from https://www.ndw.nu/documenten/nl/#cat_2.
  * Lithuania:
    * [traffic count](http://lakd.lrv.lt/lt/atviri-duomenys)
    * [restrictions](http://restrictions.eismoinfo.lt/): Roadworks, road closures and restrictions, incidents; JSON-based format similar to Waze CIFS. More information at http://eismoinfo.lt > Open data/Atviri duomenys.

--- a/README.md
+++ b/README.md
@@ -16,7 +16,9 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [Entire UK](http://www.dft.gov.uk/traffic-counts/) traffic count only, but [here](https://data.gov.uk/dataset/dft-eng-srn-routes-journey-times) seems to be some traffic flow data.
 * [Gothenbury, Sweden](http://www.statistik.tkgbg.se/)
 * [Switzerland](https://www.astra.admin.ch/astra/en/home/dokumentation/verkehrsdaten.html) traffic count only
-* [France](https://www.quandl.com/data/INSEE?keyword=traffic) traffic count only
+* France
+  * [Traffic count](https://www.quandl.com/data/INSEE?keyword=traffic)
+  * [Datex-II event data](http://diffusion-numerique.info-routiere.gouv.fr/acces-aux-donnees-evenementielles-datex-2-r13.html), requires registration
 * [Historic Road data in EU](http://open-data.europa.eu/en/data/dataset/4t2lYOaJNRsEgDA37hrUgg)
 * [Netherlands](http://83.247.110.3/ndwOpenAVG/Default.aspx) via the NDW. FTP-Server for data and measurements is ftp://83.247.110.3/ , see [#2](https://github.com/graphhopper/open-traffic-collection/issues/2). Feeds are also available at http://opendata.ndw.nu/. Specifically:
   * `brugopeningen` has time tables for movable bridges, indicating when they are opened (i.e. raised) and thus impassable for road traffic

--- a/README.md
+++ b/README.md
@@ -31,7 +31,9 @@ Collections of URLs pointing to traffic information portals which contain open d
    * [traffic count](http://lakd.lrv.lt/lt/atviri-duomenys)
    * [restrictions](http://restrictions.eismoinfo.lt/): Roadworks, road closures and restrictions, incidents; JSON-based format similar to Waze CIFS. More information at http://eismoinfo.lt > Open data/Atviri duomenys.
    * [intensity](https://old.eismoinfo.lt/traffic-intensity-service): Real-time traffic flow data. More information at http://eismoinfo.lt > Open data/Atviri duomenys (note that the URL has changed since). Note that coordinates for road segments are in LKS94 (EPSG:3346).
- * [Belgium](http://opendatastore.brussels/en/dataset/traffic-count) Real-time traffic counting in the Brussels Region.
+* Belgium:
+  * [Brussels Region](http://opendatastore.brussels/en/dataset/traffic-count): real-time traffic counting
+  * [Roadworks](http://www.verkeerscentrum.be/uitwisseling/datex2full) in Datex-II format. Relies on Alert-C for location decoding; ignore the `alertCLocationTableNumber` indicated in the Datex-II stream and use the default table for Belgium.
 * Poland:
   * [Traffic events](https://www.gddkia.gov.pl/dane/zima_html/utrdane.xml) in a custom XML format. Georeferencing is based on distance markers along the road; the WGS84 coordinate pair which accompanies the message is only suitable for display and can be significantly off. [traff-gddkia](https://gitlab.com/traffxml/traff-gddkia) is an attempt at a FOSS Java library which parses the data.
   * The [NAP](https://kpd.gddkia.gov.pl/) has Datex-II traffic data; registration is required to get access.

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ Collections of URLs pointing to traffic information portals which contain open d
   * [Traffic events](https://www.gddkia.gov.pl/dane/zima_html/utrdane.xml) in a custom XML format. Georeferencing is based on distance markers along the road; the WGS84 coordinate pair which accompanies the message is only suitable for display and can be significantly off. [traff-gddkia](https://gitlab.com/traffxml/traff-gddkia) is an attempt at a FOSS Java library which parses the data.
   * The [NAP](https://kpd.gddkia.gov.pl/) has Datex-II traffic data; registration is required to get access.
 * [Austria](https://services2.asfinag.at/web/trafficdata/documents): Various data sets in Datex-II format. Requires registration; some packages are free of charge, others only for a fee.
+* [Czechia](http://registr.dopravniinfo.cz/en/): Feeds for common traffic information, restrictions and weather. Available in both Datex-II and a custom format called DDR XML. Requires registration (free of charge) and running a server, to which the service will then push updates as they occur.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -32,6 +32,9 @@ Collections of URLs pointing to traffic information portals which contain open d
    * [restrictions](http://restrictions.eismoinfo.lt/): Roadworks, road closures and restrictions, incidents; JSON-based format similar to Waze CIFS. More information at http://eismoinfo.lt > Open data/Atviri duomenys.
    * [intensity](https://old.eismoinfo.lt/traffic-intensity-service): Real-time traffic flow data. More information at http://eismoinfo.lt > Open data/Atviri duomenys (note that the URL has changed since). Note that coordinates for road segments are in LKS94 (EPSG:3346).
  * [Belgium](http://opendatastore.brussels/en/dataset/traffic-count) Real-time traffic counting in the Brussels Region.
+* Poland:
+  * [Traffic events](https://www.gddkia.gov.pl/dane/zima_html/utrdane.xml) in a custom XML format. Georeferencing is based on distance markers along the road; the WGS84 coordinate pair which accompanies the message is only suitable for display and can be significantly off. [traff-gddkia](https://gitlab.com/traffxml/traff-gddkia) is an attempt at a FOSS Java library which parses the data.
+  * The [NAP](https://kpd.gddkia.gov.pl/) has Datex-II traffic data; registration is required to get access.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Collections of URLs pointing to traffic information portals which contain open d
   * Roadworks in [Datex-II](https://aineistot.vayla.fi/roadworks/roadworks_d2.xml) and [InfoXML](https://aineistot.vayla.fi/roadworks/roadworks_infoxml.xml) format. The Datex-II set relies on Alert-C for location referencing.
   * [Weight restrictions](https://aineistot.vayla.fi/painorajoitukset/painorajoitukset_d2.xml) in Datex-II, relies on Alert-C for location referencing.
 * [Luxembourg](http://www.cita.lu/info_trafic/datex/situationrecord): Traffic events in Datex-II format. Relies on Alert-C for location referencing.
+* [Norway](https://www.vegvesen.no/om+statens+vegvesen/om+organisasjonen/apne-data/Datex/publikasjoner): Various data sets in Datex-II format, requires registration. Relies on Alert-C for location referencing, the LCL can be downloaded from the site.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -51,6 +51,7 @@ Collections of URLs pointing to traffic information portals which contain open d
   * [Weight restrictions](https://aineistot.vayla.fi/painorajoitukset/painorajoitukset_d2.xml) in Datex-II, relies on Alert-C for location referencing.
 * [Luxembourg](http://www.cita.lu/info_trafic/datex/situationrecord): Traffic events in Datex-II format. Relies on Alert-C for location referencing.
 * [Norway](https://www.vegvesen.no/om+statens+vegvesen/om+organisasjonen/apne-data/Datex/publikasjoner): Various data sets in Datex-II format, requires registration. Relies on Alert-C for location referencing, the LCL can be downloaded from the site.
+* [Slovenia](https://www.promet.si/portal/en/etd.aspx): various data sets in Datex-II format, requires registration.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ Collections of URLs pointing to traffic information portals which contain open d
   * The [NAP](https://kpd.gddkia.gov.pl/) has Datex-II traffic data; registration is required to get access.
 * [Austria](https://services2.asfinag.at/web/trafficdata/documents): Various data sets in Datex-II format. Requires registration; some packages are free of charge, others only for a fee.
 * [Czechia](http://registr.dopravniinfo.cz/en/): Feeds for common traffic information, restrictions and weather. Available in both Datex-II and a custom format called DDR XML. Requires registration (free of charge) and running a server, to which the service will then push updates as they occur.
+* [Estonia](https://tarktee.mnt.ee/#/en/datex): road safety, traffic restrictions and real time traffic flow in Datex-II format. Location referencing seems to rely mainly on distance markers (on which data on OSM is scarce); WGS84 is used for single-point locations only; Alert-C is not used. Requires registration, free of charge.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -19,7 +19,10 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [France](https://www.quandl.com/data/INSEE?keyword=traffic) traffic count only
 * [Historic Road data in EU](http://open-data.europa.eu/en/data/dataset/4t2lYOaJNRsEgDA37hrUgg)
 * [Netherlands](http://83.247.110.3/ndwOpenAVG/Default.aspx) via the NDW. FTP-Server for data and measurements is ftp://83.247.110.3/ , see [#2](https://github.com/graphhopper/open-traffic-collection/issues/2)
- * [Lithuania](http://lakd.lrv.lt/lt/atviri-duomenys) traffic count only 
+ * Lithuania:
+   * [traffic count](http://lakd.lrv.lt/lt/atviri-duomenys)
+   * [restrictions](http://restrictions.eismoinfo.lt/): Roadworks, road closures and restrictions, incidents; JSON-based format similar to Waze CIFS. More information at http://eismoinfo.lt > Open data/Atviri duomenys.
+   * [intensity](https://old.eismoinfo.lt/traffic-intensity-service): Real-time traffic flow data. More information at http://eismoinfo.lt > Open data/Atviri duomenys (note that the URL has changed since). Note that coordinates for road segments are in LKS94 (EPSG:3346).
  * [Belgium](http://opendatastore.brussels/en/dataset/traffic-count) Real-time traffic counting in the Brussels Region.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)

--- a/README.md
+++ b/README.md
@@ -46,6 +46,7 @@ Collections of URLs pointing to traffic information portals which contain open d
   * [Digitraffic](https://www.digitraffic.fi/en/road-traffic/) has several data sets, some in a custom JSON format, others in Datex-II level C
   * Roadworks in [Datex-II](https://aineistot.vayla.fi/roadworks/roadworks_d2.xml) and [InfoXML](https://aineistot.vayla.fi/roadworks/roadworks_infoxml.xml) format. The Datex-II set relies on Alert-C for location referencing.
   * [Weight restrictions](https://aineistot.vayla.fi/painorajoitukset/painorajoitukset_d2.xml) in Datex-II, relies on Alert-C for location referencing.
+* [Luxembourg](http://www.cita.lu/info_trafic/datex/situationrecord): Traffic events in Datex-II format. Relies on Alert-C for location referencing.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -40,6 +40,10 @@ Collections of URLs pointing to traffic information portals which contain open d
 * [Austria](https://services2.asfinag.at/web/trafficdata/documents): Various data sets in Datex-II format. Requires registration; some packages are free of charge, others only for a fee.
 * [Czechia](http://registr.dopravniinfo.cz/en/): Feeds for common traffic information, restrictions and weather. Available in both Datex-II and a custom format called DDR XML. Requires registration (free of charge) and running a server, to which the service will then push updates as they occur.
 * [Estonia](https://tarktee.mnt.ee/#/en/datex): road safety, traffic restrictions and real time traffic flow in Datex-II format. Location referencing seems to rely mainly on distance markers (on which data on OSM is scarce); WGS84 is used for single-point locations only; Alert-C is not used. Requires registration, free of charge.
+* Finland:
+  * [Digitraffic](https://www.digitraffic.fi/en/road-traffic/) has several data sets, some in a custom JSON format, others in Datex-II level C
+  * Roadworks in [Datex-II](https://aineistot.vayla.fi/roadworks/roadworks_d2.xml) and [InfoXML](https://aineistot.vayla.fi/roadworks/roadworks_infoxml.xml) format. The Datex-II set relies on Alert-C for location referencing.
+  * [Weight restrictions](https://aineistot.vayla.fi/painorajoitukset/painorajoitukset_d2.xml) in Datex-II, relies on Alert-C for location referencing.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ Collections of URLs pointing to traffic information portals which contain open d
 * Poland:
   * [Traffic events](https://www.gddkia.gov.pl/dane/zima_html/utrdane.xml) in a custom XML format. Georeferencing is based on distance markers along the road; the WGS84 coordinate pair which accompanies the message is only suitable for display and can be significantly off. [traff-gddkia](https://gitlab.com/traffxml/traff-gddkia) is an attempt at a FOSS Java library which parses the data.
   * The [NAP](https://kpd.gddkia.gov.pl/) has Datex-II traffic data; registration is required to get access.
+* [Austria](https://services2.asfinag.at/web/trafficdata/documents): Various data sets in Datex-II format. Requires registration; some packages are free of charge, others only for a fee.
   
 Many EU data sets are available at the [European Data Portal](http://www.europeandataportal.eu/data/en/group/transport?q=traffic)
 


### PR DESCRIPTION
A few new sources of live traffic event and/or flow data in Europe, as well as some pointers to Datex-II and Alert-C location referencing (which many of them use).

Contains sources for Austria, Belgium, Catalonia, Czechia, Estonia, Finland, France, Italy, Lithuania, Luxembourg, Netherlands, Norway, Poland, Scotland, Slovenia and Sweden.